### PR TITLE
Fix user link indentation

### DIFF
--- a/src/lib/feeds/posts/Post.svelte
+++ b/src/lib/feeds/posts/Post.svelte
@@ -86,7 +86,7 @@
 				{#if postView.post.url && (!probablyImage || !thumbnailUrl)}
 					<PrettyExternalLink href={postView.post.url} />
 				{/if}
-				<Stack dir="r" gap={1} align="center">
+				<Stack dir="r" gap={1} align="center" cl="ml-2">
 					<UserLink user={postView.creator} />
 					<UserBadges user={postView.creator} postOP="" />
 					to


### PR DESCRIPTION
Before:
![image](https://github.com/sheodox/alexandrite/assets/1407980/6e1f1028-cff6-4d0e-9395-a5eb4b799f63)

After:
![image](https://github.com/sheodox/alexandrite/assets/1407980/bdc4f6b5-904b-457f-9b0a-c149773d31e4)
