### PR TITLE
Mark post as read on view

### DIFF
--- a/src/lib/feeds/posts/Post.svelte
+++ b/src/lib/feeds/posts/Post.svelte
@@ -426,8 +426,11 @@
 
 	onMount(async () => {
 		if (mode === 'show' && loggedIn && jwt) {
-			// getting the post has a side effect of marking comments as read
-			const pv = await client.getPost({ id: postView.post.id, auth: jwt }).then(({ post_view }) => post_view);
+			// getting the post has a side effect of marking it and its comments as read
+			const pv = await client.getPost({ id: postView.post.id, auth: jwt }).then(({ post_view }) => {
+				post_view.read = true;
+				return post_view;
+			});
 			cvStore.updateView(postViewToContentView(pv));
 		}
 	});


### PR DESCRIPTION
Calling the Lemmy Server API to get the post is already marking the post as read, so we can just update the read property on success.

Previously, the post would get visually marked as read only on the second time of opening it (because Lemmy doesn't update the read status in the response of the initial call )