### PR TITLE
Use the instance's branding in the header

### DIFF
--- a/src/lib/Avatar.svelte
+++ b/src/lib/Avatar.svelte
@@ -1,17 +1,16 @@
 <style lang="scss">
 	.avatar {
-		height: var(--avatar-size);
-		width: var(--avatar-size);
 		border-radius: var(--avatar-size);
 		display: flex;
 		justify-content: center;
 		align-items: center;
 		overflow: hidden;
+		line-height: 0;
 
 		:global(img) {
 			border-radius: var(--avatar-size);
-			height: 100%;
-			width: 100%;
+			height: var(--avatar-size);
+			width: var(--avatar-size);
 			object-fit: cover;
 		}
 	}

--- a/src/lib/Logo.svelte
+++ b/src/lib/Logo.svelte
@@ -3,6 +3,9 @@
 		width: var(--logo-size);
 		height: var(--logo-size);
 	}
+	svg.tiny {
+		--logo-size: 1.5em;
+	}
 	svg.small {
 		--logo-size: 2rem;
 	}
@@ -19,5 +22,5 @@
 </svg>
 
 <script lang="ts">
-	export let size: 'small' | 'medium' | 'large' = 'small';
+	export let size: 'tiny' | 'small' | 'medium' | 'large' = 'small';
 </script>

--- a/src/lib/feeds/posts/FeedHeader.svelte
+++ b/src/lib/feeds/posts/FeedHeader.svelte
@@ -3,7 +3,6 @@
 		height: 6rem;
 		width: 6rem;
 		border-radius: 100rem;
-		border: 3px solid var(--sx-gray-200);
 		object-fit: cover;
 	}
 	.feed-header {

--- a/src/lib/instance/InstanceSidebar.svelte
+++ b/src/lib/instance/InstanceSidebar.svelte
@@ -5,7 +5,7 @@
 	context="Your Instance"
 >
 	<span slot="name" class="f-row gap-2 align-items-center"
-		><Icon icon="network-wired" /><NameAtInstance prefix="" place={{ ...siteView.site, local: true }} />
+		><InstanceLogo size="3rem" /><NameAtInstance prefix="" place={{ ...siteView.site, local: true }} />
 	</span>
 	<Stack slot="actions" dir="c" gap={2} cl="mt-2">
 		{#each $siteMeta.taglines as tagline}
@@ -15,11 +15,12 @@
 </Sidebar>
 
 <script lang="ts">
-	import { Alert, Stack, Icon } from 'sheodox-ui';
+	import { Alert, Stack } from 'sheodox-ui';
 	import Sidebar from '$lib/Sidebar.svelte';
 	import NameAtInstance from '$lib/NameAtInstance.svelte';
 	import Markdown from '$lib/Markdown.svelte';
 	import { getAppContext } from '$lib/app-context';
+	import InstanceLogo from '../../routes/(app)/[instance]/InstanceLogo.svelte';
 
 	const { siteMeta } = getAppContext();
 	$: siteView = $siteMeta.site_view;

--- a/src/routes/(app)/[instance]/+layout.svelte
+++ b/src/routes/(app)/[instance]/+layout.svelte
@@ -14,13 +14,19 @@
 </style>
 
 <Header
-	appName="Alexandrite"
+	appName={$siteMeta.site_view.site.name}
 	href="/{$instance}"
 	showMenuTrigger={true}
 	bind:menuOpen={$navSidebarOpen}
 	position="fixed"
 >
-	<Logo slot="logo" />
+	<div slot="logo" class="header-logo">
+		{#if $siteMeta.site_view.site.icon}
+			<InstanceLogo />
+		{:else}
+			<Logo />
+		{/if}
+	</div>
 	<div slot="headerCenter">
 		<form method="GET" action="/{$instance}/search" on:submit={onSearchSubmit}>
 			<Search name="q" placeholder="Search" bind:value={headerSearchText} />
@@ -73,8 +79,8 @@
 	<Modals />
 	<Sidebar bind:menuOpen={$navSidebarOpen} docked={$navSidebarDocked}>
 		<div slot="header" class="f-row align-items-center">
-			<Logo />
-			<h1 class="ml-2">Alexandrite</h1>
+			<InstanceLogo />
+			<h1 class="ml-2 sx-font-size-4">{$siteMeta.site_view.site.name}</h1>
 		</div>
 
 		<AppSidebar subscriptions={$siteMeta.my_user?.follows ?? []} />
@@ -116,6 +122,8 @@
 	import { localStorageBackedStore } from '$lib/utils';
 	import { AlexandriteSettingsDefaults } from '$lib/settings-context';
 	import { profile, instance } from '$lib/profiles/profiles';
+	import Avatar from '$lib/Avatar.svelte';
+	import InstanceLogo from './InstanceLogo.svelte';
 
 	export let data;
 

--- a/src/routes/(app)/[instance]/+layout.svelte
+++ b/src/routes/(app)/[instance]/+layout.svelte
@@ -122,7 +122,6 @@
 	import { localStorageBackedStore } from '$lib/utils';
 	import { AlexandriteSettingsDefaults } from '$lib/settings-context';
 	import { profile, instance } from '$lib/profiles/profiles';
-	import Avatar from '$lib/Avatar.svelte';
 	import InstanceLogo from './InstanceLogo.svelte';
 
 	export let data;

--- a/src/routes/(app)/[instance]/AppSidebar.svelte
+++ b/src/routes/(app)/[instance]/AppSidebar.svelte
@@ -11,6 +11,11 @@
 </style>
 
 <div>
+	<Stack cl="mx-4 sx-badge-gray sx-font-size-2" dir="r" align="center" gap={1}>
+		<Logo size="tiny" />
+		<span class="fw-normal">Powered by</span>
+		<ExternalLink href="https://github.com/sheodox/alexandrite">Alexandrite</ExternalLink>
+	</Stack>
 	<nav class="sx-sidebar-simple-links">
 		<Stack dir="c" gap={1}>
 			{#each links as link}
@@ -45,11 +50,12 @@
 
 <script lang="ts">
 	import type { CommunityFollowerView } from 'lemmy-js-client';
-	import { Stack, Icon } from 'sheodox-ui';
+	import { Stack, ExternalLink, Icon } from 'sheodox-ui';
 	import SidebarSubscriptionList from './SidebarSubscriptionList.svelte';
 	import { getAppContext } from '$lib/app-context';
 	import { localStorageBackedStore } from '$lib/utils';
 	import { profile } from '$lib/profiles/profiles';
+	import Logo from '$lib/Logo.svelte';
 
 	export let subscriptions: CommunityFollowerView[] = [];
 

--- a/src/routes/(app)/[instance]/InstanceLogo.svelte
+++ b/src/routes/(app)/[instance]/InstanceLogo.svelte
@@ -1,0 +1,9 @@
+<Avatar src={$siteMeta.site_view.site.icon} icon="network-external" {size} resolution={96} />
+
+<script lang="ts">
+	import Avatar from '$lib/Avatar.svelte';
+	import { getAppContext } from '$lib/app-context';
+	const { siteMeta } = getAppContext();
+
+	export let size = '2rem';
+</script>


### PR DESCRIPTION
This changes the "Alexandrite" header and logo to show the instance you're on, using their logo and name. There's now a smaller "Powered by Alexandrite" with logo in the sidebar just below it.