### PR TITLE
Smaller header app name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
 				"prettier": "^3.0.0",
 				"prettier-plugin-svelte": "^3.0.0",
 				"sass": "^1.64.1",
-				"sheodox-ui": "^0.20.2",
+				"sheodox-ui": "^0.20.3",
 				"svelte": "^4.1.1",
 				"svelte-check": "^3.4.6",
 				"tslib": "^2.6.1",
@@ -3531,9 +3531,9 @@
 			}
 		},
 		"node_modules/sheodox-ui": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/sheodox-ui/-/sheodox-ui-0.20.2.tgz",
-			"integrity": "sha512-kS/Rev5rAOeGzfRS2U/QLdTgCJMBfX8g8lF/xY0KW9YMuL5FRP5O929+zmlnvLyOQOooNwwyyzS290ljTA3U0Q==",
+			"version": "0.20.3",
+			"resolved": "https://registry.npmjs.org/sheodox-ui/-/sheodox-ui-0.20.3.tgz",
+			"integrity": "sha512-ZLcbaGn76+//5R432L2Qhg2lGvUWVQV1JRzblq00s3vk7HmRY9hYjUlkL7oqwEqtpVWblqUBHbOapHlm9FbuNQ==",
 			"dev": true,
 			"dependencies": {
 				"@floating-ui/dom": "^1.2.9",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"prettier": "^3.0.0",
 		"prettier-plugin-svelte": "^3.0.0",
 		"sass": "^1.64.1",
-		"sheodox-ui": "^0.20.2",
+		"sheodox-ui": "^0.20.3",
 		"svelte": "^4.1.1",
 		"svelte-check": "^3.4.6",
 		"tslib": "^2.6.1",


### PR DESCRIPTION
This updates sheodox-ui, which includes a change making the slim `<Header>` variant have smaller text for the app name. This seems to look more modern to me.