### PR TITLE
feat issue: Feature Request: Add 'scaled' option to sort options #92

### DIFF
--- a/src/lib/feed-filters.ts
+++ b/src/lib/feed-filters.ts
@@ -119,6 +119,10 @@ export const PostSortOptions = [
 		label: 'Active'
 	},
 	{
+		value: 'Scaled',
+		label: 'Scaled'
+	},
+	{
 		value: 'New',
 		label: 'New'
 	},


### PR DESCRIPTION
Completes #92 

Added the 'Scaled' post sorting option to the PostSortOptions object.

Tested in docker and it works as expected.