### PR TITLE
0.8.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "Alexandrite",
-	"version": "0.8.16",
+	"version": "0.8.17",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "Alexandrite",
-			"version": "0.8.16",
+			"version": "0.8.17",
 			"dependencies": {
 				"@fortawesome/fontawesome-free": "^6.4.2",
 				"date-fns": "^2.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Alexandrite",
-	"version": "0.8.16",
+	"version": "0.8.17",
 	"private": true,
 	"scripts": {
 		"dev": "vite dev --host 0.0.0.0",

--- a/src/lib/CommunityCard.svelte
+++ b/src/lib/CommunityCard.svelte
@@ -30,6 +30,8 @@
 		</Stack>
 
 		<Stack cl="card-body" dir="c" gap={2}>
+			{@const communityAddress = '!' + nameAtInstance(communityView.community, '', { alwaysShowInstance: true })}
+			<CopyableText text={communityAddress} />
 			<CommunityBadges extended community={communityView.community} />
 			<Stack dir="r" align="center" gap={2}>
 				<CommunityJoin {communityView} />
@@ -56,6 +58,7 @@
 	import CommunityCounts from '$lib/CommunityCounts.svelte';
 	import CommunityJoin from '$lib/CommunityJoin.svelte';
 	import { profile } from '$lib/profiles/profiles';
+	import CopyableText from './CopyableText.svelte';
 
 	export let communityView: CommunityView;
 	$: communityName = nameAtInstance(communityView.community);

--- a/src/lib/CommunitySidebar.svelte
+++ b/src/lib/CommunitySidebar.svelte
@@ -1,3 +1,9 @@
+<style lang="scss">
+	.community-address {
+		align-self: start;
+	}
+</style>
+
 <article>
 	{#if community && communityView}
 		<Sidebar description={community.description ?? ''} context="Community" bind:descriptionOpen={$descriptionOpen}>
@@ -9,6 +15,11 @@
 				<Stack dir="c" gap={2}>
 					{#if communityView}
 						<CommunityCounts {communityView} />
+					{/if}
+					{#if communityAddress}
+						<div class="community-address">
+							<CopyableText text={communityAddress} />
+						</div>
 					{/if}
 				</Stack>
 			</div>
@@ -81,6 +92,7 @@
 	import { getModActionPending, getModContext } from './mod/mod-context';
 	import { readable } from 'svelte/store';
 	import { localStorageBackedStore } from './utils';
+	import CopyableText from './CopyableText.svelte';
 
 	export let communityName: string;
 
@@ -132,6 +144,7 @@
 	];
 
 	$: communityInstance = community ? new URL(community.actor_id).host : null;
+	$: communityAddress = community ? '!' + nameAtInstance(community, '', { alwaysShowInstance: true }) : '';
 
 	const { siteMeta, userId } = getAppContext();
 	const { showModlogWarning, showModlogWarningModerated } = getSettingsContext();

--- a/src/lib/CommunitySidebar.svelte
+++ b/src/lib/CommunitySidebar.svelte
@@ -26,50 +26,52 @@
 			<div slot="end">
 				<Accordion bind:open={$communityDetailsOpen}>
 					<span slot="title"><Icon icon="users" /> Community Details</span>
-					<ul class="sx-list mb-2">
-						{#each communityStats as stat}
-							<li class="sx-list-item two-columns">
-								<span class="column">{stat.label}</span>
-								<span class="column text-align-right">{stat.value.toLocaleString()} <Icon icon={stat.icon} /></span>
+					<div class="f-column gap-2">
+						<ul class="sx-list">
+							{#each communityStats as stat}
+								<li class="sx-list-item two-columns">
+									<span class="column">{stat.label}</span>
+									<span class="column text-align-right">{stat.value.toLocaleString()} <Icon icon={stat.icon} /></span>
+								</li>
+							{/each}
+							<li class="sx-list-item">
+								<ModlogLink
+									communityId={community.id}
+									highlight={userModerates ?? false}
+									highlightColor="green"
+									warn={warnModlog}
+								/>
 							</li>
-						{/each}
-						<li class="sx-list-item">
-							<ModlogLink
-								communityId={community.id}
-								highlight={userModerates ?? false}
-								highlightColor="green"
-								warn={warnModlog}
-							/>
-						</li>
-						<li class="sx-list-item">
-							<ExternalLink href={community.actor_id} cl="inline-link">
-								<Icon icon="arrow-up-right-from-square" />
-								View on {communityInstance}
-							</ExternalLink>
-						</li>
-					</ul>
+							<li class="sx-list-item">
+								<ExternalLink href={community.actor_id} cl="inline-link">
+									<Icon icon="arrow-up-right-from-square" />
+									View on {communityInstance}
+								</ExternalLink>
+							</li>
+						</ul>
 
-					{#if moderators}
-						<Accordion>
-							<span slot="title">Moderators</span>
-							<Stack dir="c" gap={2}>
-								<ul class="sx-list">
-									{#each moderators as mod}
-										<li class="sx-list-item">
-											<ModeratorRow hasSeniority={hasModSeniority(moderators, mod.moderator.id)} {mod} />
-										</li>
-									{/each}
-								</ul>
-								{#if userModerates && !userIsHeadMod}
-									<Stack dir="r" justify="end">
-										<BusyButton small icon="user-minus" busy={$userModResignPending} on:click={resignFromModTeam}
-											>Leave Mod Team</BusyButton
-										>
-									</Stack>
-								{/if}
-							</Stack>
-						</Accordion>
-					{/if}
+						{#if moderators}
+							<Accordion>
+								<span slot="title">Moderators</span>
+								<Stack dir="c" gap={2}>
+									<ul class="sx-list">
+										{#each moderators as mod}
+											<li class="sx-list-item">
+												<ModeratorRow hasSeniority={hasModSeniority(moderators, mod.moderator.id)} {mod} />
+											</li>
+										{/each}
+									</ul>
+									{#if userModerates && !userIsHeadMod}
+										<Stack dir="r" justify="end">
+											<BusyButton small icon="user-minus" busy={$userModResignPending} on:click={resignFromModTeam}
+												>Leave Mod Team</BusyButton
+											>
+										</Stack>
+									{/if}
+								</Stack>
+							</Accordion>
+						{/if}
+					</div>
 				</Accordion>
 			</div>
 		</Sidebar>

--- a/src/lib/CommunitySidebar.svelte
+++ b/src/lib/CommunitySidebar.svelte
@@ -17,7 +17,7 @@
 						<CommunityCounts {communityView} />
 					{/if}
 					{#if communityAddress}
-						<div class="community-address">
+						<div class="community-address mb-4">
 							<CopyableText text={communityAddress} />
 						</div>
 					{/if}
@@ -26,7 +26,7 @@
 			<div slot="end">
 				<Accordion bind:open={$communityDetailsOpen}>
 					<span slot="title"><Icon icon="users" /> Community Details</span>
-					<ul class="sx-list">
+					<ul class="sx-list mb-2">
 						{#each communityStats as stat}
 							<li class="sx-list-item two-columns">
 								<span class="column">{stat.label}</span>

--- a/src/lib/CommunitySidebar.svelte
+++ b/src/lib/CommunitySidebar.svelte
@@ -8,7 +8,7 @@
 	{#if community && communityView}
 		<Sidebar description={community.description ?? ''} context="Community" bind:descriptionOpen={$descriptionOpen}>
 			<a href={communityHref} slot="name">
-				<NameAtInstance place={community} prefix="!" />
+				<NameAtInstance place={community} displayName={community.title} />
 			</a>
 
 			<div slot="actions">

--- a/src/lib/CopyableText.svelte
+++ b/src/lib/CopyableText.svelte
@@ -1,0 +1,24 @@
+<style lang="scss">
+	.copyable-text {
+		background: var(--sx-gray-transparent-dark);
+		align-self: start;
+		border-radius: 10px;
+		overflow: hidden;
+		border: 1px solid var(--sx-gray-transparent-light);
+	}
+	.text-preview {
+		font-family: monospace, sans-serif;
+	}
+</style>
+
+<p class="copyable-text m-0 px-4 py-2 f-row align-items-center gap-2">
+	<span class="text-preview">{text}</span>
+	<IconButton icon="copy" text="Copy" small on:click={() => copyToClipboard(text)} />
+</p>
+
+<script lang="ts">
+	import IconButton from './IconButton.svelte';
+	import { copyToClipboard } from './utils';
+
+	export let text: string;
+</script>

--- a/src/lib/CopyableText.svelte
+++ b/src/lib/CopyableText.svelte
@@ -8,12 +8,15 @@
 	}
 	.text-preview {
 		font-family: monospace, sans-serif;
+		cursor: pointer;
 	}
 </style>
 
-<p class="copyable-text m-0 px-4 py-2 f-row align-items-center gap-2">
-	<span class="text-preview">{text}</span>
-	<IconButton icon="copy" text="Copy" small on:click={() => copyToClipboard(text)} />
+<p class="copyable-text m-0 px-4 py-2 f-row align-items-center gap-2" bind:this={el}>
+	<!-- ignoring warnings because there's a button for accessibility, but people will want to click the text too -->
+	<!-- svelte-ignore a11y-no-static-element-interactions a11y-click-events-have-key-events -->
+	<span class="text-preview" on:click={copy}>{text}</span>
+	<IconButton icon="copy" text="Copy" small on:click={copy} />
 </p>
 
 <script lang="ts">
@@ -21,4 +24,23 @@
 	import { copyToClipboard } from './utils';
 
 	export let text: string;
+
+	let el: HTMLParagraphElement;
+
+	function copy() {
+		copyToClipboard(text);
+		el.animate(
+			[
+				{
+					background: 'var(--sx-gray-transparent)'
+				},
+				{
+					background: 'var(--sx-gray-dark)'
+				}
+			],
+			{
+				duration: 200
+			}
+		);
+	}
 </script>

--- a/src/lib/DescriptiveToggles.svelte
+++ b/src/lib/DescriptiveToggles.svelte
@@ -19,7 +19,7 @@
 		{/each}
 	</div>
 	{@const selected = options.find((opt) => opt.value === group)}
-	{#if selected}
+	{#if selected && selected.description}
 		<p class="muted description mb-0 px-1">
 			<Icon icon="question-circle" variant="regular" />
 			<strong>{selected.label}:</strong>
@@ -33,7 +33,7 @@
 	import { Fieldset, Icon } from 'sheodox-ui';
 	import { genId } from 'sheodox-ui/util';
 
-	export let options: { value: string | null; label: string; description: string }[];
+	export let options: { value: string | null; label: string; description?: string }[];
 	export let legend: string;
 	export let group: (typeof options)[number]['value'];
 

--- a/src/lib/NameAtInstance.svelte
+++ b/src/lib/NameAtInstance.svelte
@@ -5,6 +5,7 @@
 	export let displayName = '';
 	export let prefix = ''; // @, !, /m/ etc
 	export let wrappable = true;
+	export let alwaysShowInstance = false;
 
 	$: name = displayName || place.name;
 	$: instance = getInstance(place);
@@ -15,7 +16,7 @@
 		actor_id: string;
 	}
 	const getInstance = (thing: NamedThing) => {
-		if (!thing.local) {
+		if (!thing.local || alwaysShowInstance) {
 			return '@' + new URL(thing.actor_id).hostname;
 		}
 		return '';

--- a/src/lib/PersonCard.svelte
+++ b/src/lib/PersonCard.svelte
@@ -10,10 +10,13 @@
 	.icon :global(img) {
 		object-fit: cover;
 	}
+	.user-address {
+		align-self: start;
+	}
 </style>
 
 <div class="p-2">
-	<div class="card p-4">
+	<div class="card p-4 f-column gap-2">
 		<Stack dir="r" align="center" cl="card-title" gap={2}>
 			<div class="icon f-row align-items-center justify-content-center">
 				{#if personView.person.avatar && $profile.settings.show_avatars}
@@ -27,7 +30,11 @@
 			</a>
 		</Stack>
 
-		<div class="card-body">
+		<div class="user-address">
+			<CopyableText text={userAddress} />
+		</div>
+
+		<div class="card-body p-0">
 			<ul class="sx-list">
 				<UserCounts {personView} />
 			</ul>
@@ -43,6 +50,8 @@
 	import type { PersonView } from 'lemmy-js-client';
 	import UserCounts from './UserCounts.svelte';
 	import { profile } from './profiles/profiles';
+	import CopyableText from './CopyableText.svelte';
 
 	export let personView: PersonView;
+	$: userAddress = '@' + nameAtInstance(personView.person, '', { alwaysShowInstance: true });
 </script>

--- a/src/lib/PostPage.svelte
+++ b/src/lib/PostPage.svelte
@@ -227,7 +227,7 @@
 	export let crossPosts: PostView[] | null = null;
 
 	const showNewCommentComposer = localStorageBackedStore('show-new-comment-composer', true);
-	const { sidebarVisible, nsfwImageHandling } = getSettingsContext();
+	const { sidebarVisible, nsfwImageHandling, commentDefaultSort } = getSettingsContext();
 	const { screenDimensions } = getAppContext();
 
 	let commentAPIs: CommentAPI[] | undefined;
@@ -253,7 +253,7 @@
 	let commentExpandLoadingIds = new Set<number>(),
 		newCommentForm: HTMLFormElement,
 		commentsPageNum = 1,
-		selectedSort = 'Hot',
+		selectedSort = $commentDefaultSort,
 		newCommentText = '',
 		searchText = '',
 		loadingComments = false,

--- a/src/lib/VirtualFeed.svelte
+++ b/src/lib/VirtualFeed.svelte
@@ -22,7 +22,11 @@
 				</div>
 			{/each}
 		</div>
-		<InfiniteFeed {endOfFeed} {feedEndIcon} {feedEndMessage} {loading} {loadMoreFailed} on:more />
+		<InfiniteFeed {endOfFeed} {feedEndIcon} {feedEndMessage} {loading} {loadMoreFailed} on:more>
+			<div slot="feed-end-banner">
+				<slot name="feed-end-banner" />
+			</div>
+		</InfiniteFeed>
 	</div>
 </div>
 

--- a/src/lib/feed-filters.ts
+++ b/src/lib/feed-filters.ts
@@ -250,19 +250,28 @@ export const InboxSortOptions = [
 export const CommentSortOptions = [
 	{
 		value: 'Hot',
-		label: 'Hot'
+		label: 'Hot',
+		description: ''
 	},
 	{
 		value: 'Top',
-		label: 'Top'
+		label: 'Top',
+		description: ''
+	},
+	{
+		value: 'Controversial',
+		label: 'Controversial',
+		description: ''
 	},
 	{
 		value: 'New',
-		label: 'New'
+		label: 'New',
+		description: ''
 	},
 	{
 		value: 'Old',
-		label: 'Old'
+		label: 'Old',
+		description: ''
 	}
 ];
 

--- a/src/lib/feeds/posts/FeedBanner.svelte
+++ b/src/lib/feeds/posts/FeedBanner.svelte
@@ -5,7 +5,7 @@
 </style>
 
 <section class="feed-banner f-row justify-content-center">
-	<Stack dir="c" align="center" justify="center" cl="f-1">
+	<Stack dir="c" align="center" justify="center" cl="f-1" gap={4}>
 		<p class="m-0 sx-font-size-12">
 			{#if loading}
 				<Spinner />

--- a/src/lib/feeds/posts/FeedHeader.svelte
+++ b/src/lib/feeds/posts/FeedHeader.svelte
@@ -13,8 +13,26 @@
 		flex-shrink: 0;
 	}
 
+	.feed-header :global(:is(button.tertiary, a.button)) {
+		background: var(--sx-gray-500);
+		&:hover {
+			background: var(--sx-gray-400);
+		}
+	}
+
+	h1 {
+		text-shadow:
+			0 0 100px black,
+			0 0 50px black,
+			0 0 25px black;
+	}
+
+	.sx-badge-gray {
+		background: var(--sx-gray-600) !important;
+	}
+
 	.banner {
-		opacity: 0.4;
+		opacity: 0.8;
 		position: absolute;
 		top: 0;
 		right: 0;

--- a/src/lib/feeds/posts/FeedHeader.svelte
+++ b/src/lib/feeds/posts/FeedHeader.svelte
@@ -14,7 +14,7 @@
 	}
 
 	.banner {
-		opacity: 0.6;
+		opacity: 0.4;
 		position: absolute;
 		top: 0;
 		right: 0;

--- a/src/lib/feeds/posts/FeedHeader.svelte
+++ b/src/lib/feeds/posts/FeedHeader.svelte
@@ -13,7 +13,7 @@
 		flex-shrink: 0;
 	}
 
-	.feed-header :global(:is(button.tertiary, a.button)) {
+	.feed-header.has-banner :global(:is(button.tertiary, a.button)) {
 		background: var(--sx-gray-500);
 		&:hover {
 			background: var(--sx-gray-400);
@@ -50,7 +50,7 @@
 	}
 </style>
 
-<section class="{narrow ? 'p-3' : 'p-8'} feed-header">
+<section class="{narrow ? 'p-3' : 'p-8'} feed-header" class:has-banner={!!banner}>
 	<div
 		class="banner"
 		style={`background: ${banner ? `center / cover no-repeat url(${banner})` : 'var(--sx-gray-800)'}`}

--- a/src/lib/feeds/posts/InfiniteFeed.svelte
+++ b/src/lib/feeds/posts/InfiniteFeed.svelte
@@ -12,7 +12,9 @@
 		<button class="tertiary" on:click={() => dispatch('more')} disabled={loading}> Load More</button>
 	</FeedBanner>
 {:else}
-	<FeedBanner message={feedEndMessage} icon={feedEndIcon} />
+	<FeedBanner message={feedEndMessage} icon={feedEndIcon}>
+		<slot name="feed-end-banner" />
+	</FeedBanner>
 {/if}
 
 <script lang="ts">

--- a/src/lib/instance/InstanceSidebar.svelte
+++ b/src/lib/instance/InstanceSidebar.svelte
@@ -16,7 +16,7 @@
 	<div slot="end" class="f-column gap-4">
 		<Accordion bind:open={$instanceDetailsOpen}>
 			<span slot="title"><Icon icon="server" /> Instance Details</span>
-			<div class="f-column gap-4">
+			<div class="f-column gap-2">
 				<ul class="sx-list">
 					{#each serverStats as stat}
 						<li class="sx-list-item two-columns">

--- a/src/lib/nav-utils.ts
+++ b/src/lib/nav-utils.ts
@@ -6,9 +6,9 @@ interface NamedThing {
 	actor_id: string;
 }
 
-export const nameAtInstance = (thing: NamedThing, displayName?: string) => {
+export const nameAtInstance = (thing: NamedThing, displayName?: string, opts?: { alwaysShowInstance: boolean }) => {
 	let name = displayName || thing.name;
-	if (!thing.local) {
+	if (!thing.local || opts?.alwaysShowInstance) {
 		const host = new URL(thing.actor_id).hostname;
 		name += '@' + host;
 	}

--- a/src/lib/settings-context.ts
+++ b/src/lib/settings-context.ts
@@ -1,3 +1,4 @@
+import type { CommentSortType } from 'lemmy-js-client';
 import { getContext, setContext } from 'svelte';
 import { writable, type Writable } from 'svelte/store';
 
@@ -90,6 +91,7 @@ export interface AlexandriteSettings {
 	navSidebarDocked: boolean;
 	loadImagesAsWebp: boolean;
 	feedLayout: FeedLayout;
+	commentDefaultSort: CommentSortType;
 	postPreviewLayout: PostPreviewLayout;
 	postListLayoutContentPreview: boolean;
 	postCardLayoutLeftAlignedButtons: boolean;
@@ -118,6 +120,7 @@ export const AlexandriteSettingsDefaults: AlexandriteSettings = {
 	postPreviewLayout: probablyMobile ? 'CARD' : 'LIST',
 	postListLayoutContentPreview: false,
 	postCardLayoutLeftAlignedButtons: true,
+	commentDefaultSort: 'Hot',
 	showModlogWarning: true,
 	showModlogWarningModerated: true
 };

--- a/src/routes/(app)/[instance]/+layout.svelte
+++ b/src/routes/(app)/[instance]/+layout.svelte
@@ -184,6 +184,10 @@
 			'post-card-layout-left-aligned-buttons',
 			AlexandriteSettingsDefaults.postCardLayoutLeftAlignedButtons
 		),
+		commentDefaultSort = localStorageBackedStore(
+			'comment-default-sort',
+			AlexandriteSettingsDefaults.commentDefaultSort
+		),
 		navSidebarOpen = writable(false),
 		navSidebarDocked = localStorageBackedStore('nav-sidebar-docked', AlexandriteSettingsDefaults.navSidebarDocked),
 		colorScheme = localStorageBackedStore('color-scheme', AlexandriteSettingsDefaults.colorScheme),
@@ -272,6 +276,7 @@
 		postPreviewLayout,
 		postListLayoutContentPreview,
 		postCardLayoutLeftAlignedButtons,
+		commentDefaultSort,
 		showModlogWarning,
 		showModlogWarningModerated
 	});

--- a/src/routes/(app)/[instance]/AppSidebar.svelte
+++ b/src/routes/(app)/[instance]/AppSidebar.svelte
@@ -8,64 +8,76 @@
 			width: 2.5rem;
 		}
 	}
+
+	.separator {
+		border-bottom: 1px solid var(--sx-gray-transparent-light);
+		width: 100%;
+	}
 </style>
 
 <div>
-	<Stack cl="mx-4 sx-badge-gray sx-font-size-2" dir="r" align="center" gap={1}>
+	<Stack cl="mx-2 sx-badge-gray sx-font-size-2" dir="r" align="center" gap={1}>
 		<Logo size="tiny" />
 		<span class="fw-normal">Powered by</span>
 		<ExternalLink href="https://github.com/sheodox/alexandrite">Alexandrite</ExternalLink>
 	</Stack>
-	<nav class="sx-sidebar-simple-links">
-		<Stack dir="c" gap={1}>
-			{#each links as link}
-				<a href={link.href} class="icon-link plain-link"><Icon icon={link.icon} /> <span>{link.text}</span></a>
-			{/each}
+	<nav class="sx-sidebar-simple-links p-0 mt-4">
+		<Stack dir="c" gap={4}>
+			<div class="separator" />
+			<div class="f-column gap-1 px-2">
+				{#each links as link}
+					<a href={link.href} class="icon-link plain-link"><Icon icon={link.icon} /> <span>{link.text}</span></a>
+				{/each}
+			</div>
 
-			{#if combinedCommunityList.length > 0}
-				<TextInput bind:value={communitySearch} placeholder="type name or @instance">Search Communities</TextInput>
-			{/if}
+			<div class="separator" />
 
-			{#if communitySearch !== ''}
-				<SidebarSubscriptionList
-					title="Search Results"
-					communities={searchCommunities(communitySearch, combinedCommunityList)}
-					favorites={$favoriteCommunitiesIds}
-					on:favorite={(e) => onFavorite(e.detail)}
-				/>
-				{#if !communitySearch.startsWith('@')}
-					<a
-						href="/{$profile.instance}/search?q={encodeURIComponent(communitySearch)}&type=Communities"
-						class="inline-link"
-					>
-						Search <em>"{communitySearch}"</em>
-						<Icon icon="arrow-right" />
-					</a>
+			<div class="f-column gap-1 px-2">
+				{#if combinedCommunityList.length > 0}
+					<TextInput bind:value={communitySearch} placeholder="type name or @instance">Search Communities</TextInput>
 				{/if}
-			{:else}
-				<SidebarSubscriptionList
-					title="Favorites"
-					communities={favoriteCommunities.map((v) => v.community)}
-					favorites={$favoriteCommunitiesIds}
-					on:favorite={(e) => onFavorite(e.detail)}
-				/>
 
-				{#if $siteMeta.my_user}
+				{#if communitySearch !== ''}
 					<SidebarSubscriptionList
-						title="Moderating"
-						communities={$siteMeta.my_user.moderates.map((v) => v.community)}
+						title="Search Results"
+						communities={searchCommunities(communitySearch, combinedCommunityList)}
+						favorites={$favoriteCommunitiesIds}
+						on:favorite={(e) => onFavorite(e.detail)}
+					/>
+					{#if !communitySearch.startsWith('@')}
+						<a
+							href="/{$profile.instance}/search?q={encodeURIComponent(communitySearch)}&type=Communities"
+							class="inline-link"
+						>
+							Search <em>"{communitySearch}"</em>
+							<Icon icon="arrow-right" />
+						</a>
+					{/if}
+				{:else}
+					<SidebarSubscriptionList
+						title="Favorites"
+						communities={favoriteCommunities.map((v) => v.community)}
+						favorites={$favoriteCommunitiesIds}
+						on:favorite={(e) => onFavorite(e.detail)}
+					/>
+
+					{#if $siteMeta.my_user}
+						<SidebarSubscriptionList
+							title="Moderating"
+							communities={$siteMeta.my_user.moderates.map((v) => v.community)}
+							favorites={$favoriteCommunitiesIds}
+							on:favorite={(e) => onFavorite(e.detail)}
+						/>
+					{/if}
+
+					<SidebarSubscriptionList
+						title="Subscriptions"
+						communities={subscriptions.map((v) => v.community)}
 						favorites={$favoriteCommunitiesIds}
 						on:favorite={(e) => onFavorite(e.detail)}
 					/>
 				{/if}
-
-				<SidebarSubscriptionList
-					title="Subscriptions"
-					communities={subscriptions.map((v) => v.community)}
-					favorites={$favoriteCommunitiesIds}
-					on:favorite={(e) => onFavorite(e.detail)}
-				/>
-			{/if}
+			</div>
 		</Stack>
 	</nav>
 </div>

--- a/src/routes/(app)/[instance]/settings/+page.svelte
+++ b/src/routes/(app)/[instance]/settings/+page.svelte
@@ -15,6 +15,7 @@
 	<DescriptiveToggles legend="NSFW Thumbnails" options={NSFWHandlingOptions} bind:group={$nsfwImageHandling} />
 	<FeedPostLayoutSettings />
 	<FeedLayoutSettings />
+	<CommentDefaultSortSettings />
 </Stack>
 
 <script lang="ts">
@@ -24,6 +25,7 @@
 	import DescriptiveToggles from '$lib/DescriptiveToggles.svelte';
 	import FeedPostLayoutSettings from './FeedPostLayoutSettings.svelte';
 	import ThemeSettings from './ThemeSettings.svelte';
+	import CommentDefaultSortSettings from './CommentDefaultSortSettings.svelte';
 	import { getAppContext } from '$lib/app-context';
 
 	const { navSidebarOpen, siteMeta } = getAppContext();

--- a/src/routes/(app)/[instance]/settings/CommentDefaultSortSettings.svelte
+++ b/src/routes/(app)/[instance]/settings/CommentDefaultSortSettings.svelte
@@ -1,0 +1,9 @@
+<DescriptiveToggles legend="Comment Default Sort" bind:group={$commentDefaultSort} options={CommentSortOptions} />
+
+<script lang="ts">
+	import DescriptiveToggles from '$lib/DescriptiveToggles.svelte';
+	import { CommentSortOptions } from '$lib/feed-filters';
+	import { getSettingsContext } from '$lib/settings-context';
+
+	const { commentDefaultSort } = getSettingsContext();
+</script>

--- a/src/routes/(app)/[instance]/u/[username]/+page.svelte
+++ b/src/routes/(app)/[instance]/u/[username]/+page.svelte
@@ -4,6 +4,10 @@
 		border-radius: 10px;
 		overflow: hidden;
 	}
+
+	.user-address {
+		align-self: start;
+	}
 </style>
 
 <Title title={data.personUsername} />
@@ -31,6 +35,10 @@
 							prefix="@"
 						/>
 					</h1>
+
+					<div class="user-address">
+						<CopyableText text={userAddress} />
+					</div>
 
 					{#if isMe}
 						<a class="button secondary w-100 m-0 text-align-center mb-4" href="/{$profile.instance}/settings/lemmy">
@@ -114,6 +122,8 @@
 	import { getSettingsContext } from '$lib/settings-context';
 	import { profile } from '$lib/profiles/profiles';
 	import { localStorageBackedStore } from '$lib/utils';
+	import CopyableText from '$lib/CopyableText.svelte';
+	import { nameAtInstance } from '$lib/nav-utils';
 
 	export let data;
 
@@ -130,6 +140,7 @@
 	}
 
 	$: isMe = data.personView.person.local && data.personView.person.name === $profile.username;
+	$: userAddress = '@' + nameAtInstance(data.personView.person, '', { alwaysShowInstance: true });
 
 	function refresh(data: PageData) {
 		loader = initFeed(data);


### PR DESCRIPTION
* Add a button to the 'no more messages' banner at the bottom of the banner, which switches you to viewing 'All' instead of 'Unread'.
* Added a default comment sort setting, and added 'Controversial'
* User/community sidebars and search results now have a copyable 'address' (e.g. `!alexandrite@lemmy.world`) 
* Left sidebar has separators between various sections and looks a little nicer