### PR TITLE
0.8.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # followed this guide, adapted to sveltekit
 # https://snyk.io/blog/10-best-practices-to-containerize-nodejs-web-applications-with-docker/
-FROM node:18.17.0-bookworm-slim as build
+FROM node:18.20.6-bookworm-slim as build
 RUN apt-get update && apt-get install -y --no-install-recommends dumb-init
 ENV ALEXANDRITE_RUN_IN_NODE=true
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
 				"prettier": "^3.0.3",
 				"prettier-plugin-svelte": "^3.0.3",
 				"sass": "^1.69.4",
-				"sheodox-ui": "^0.20.10",
+				"sheodox-ui": "^0.20.11",
 				"svelte": "^4.2.2",
 				"svelte-check": "^3.5.2",
 				"tslib": "^2.6.2",
@@ -3462,9 +3462,9 @@
 			}
 		},
 		"node_modules/sheodox-ui": {
-			"version": "0.20.10",
-			"resolved": "https://registry.npmjs.org/sheodox-ui/-/sheodox-ui-0.20.10.tgz",
-			"integrity": "sha512-OBQIu/idD6pRXcJHYfvRRqTIV4DJLwsSKqrxQRzmVBv1ZGGnNqRrnEaBZowVdjCl1T+RZ2plsGNeQkqN9WUpTg==",
+			"version": "0.20.11",
+			"resolved": "https://registry.npmjs.org/sheodox-ui/-/sheodox-ui-0.20.11.tgz",
+			"integrity": "sha512-IrefDxzmX7+CKFDX9YF2rkpHxEeifXfMsEfn1ykOtokTwCtc+Qdum3zbgFcRJLf8ylgl07h51d4WRx434CORVQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "Alexandrite",
-	"version": "0.8.18",
+	"version": "0.8.19",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "Alexandrite",
-			"version": "0.8.18",
+			"version": "0.8.19",
 			"dependencies": {
 				"@fortawesome/fontawesome-free": "^6.4.2",
 				"date-fns": "^2.30.0",
@@ -3982,9 +3982,9 @@
 			"dev": true
 		},
 		"node_modules/vite": {
-			"version": "4.5.5",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-4.5.5.tgz",
-			"integrity": "sha512-ifW3Lb2sMdX+WU91s3R0FyQlAyLxOzCSCP37ujw0+r5POeHPwe6udWVIElKQq8gk3t7b8rkmvqC6IHBpCff4GQ==",
+			"version": "4.5.9",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-4.5.9.tgz",
+			"integrity": "sha512-qK9W4xjgD3gXbC0NmdNFFnVFLMWSNiR3swj957yutwzzN16xF/E7nmtAyp1rT9hviDroQANjE4HK3H4WqWdFtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Alexandrite",
-	"version": "0.8.18",
+	"version": "0.8.19",
 	"private": true,
 	"scripts": {
 		"dev": "vite dev --host 0.0.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"prettier": "^3.0.3",
 		"prettier-plugin-svelte": "^3.0.3",
 		"sass": "^1.69.4",
-		"sheodox-ui": "^0.20.10",
+		"sheodox-ui": "^0.20.11",
 		"svelte": "^4.2.2",
 		"svelte-check": "^3.5.2",
 		"tslib": "^2.6.2",

--- a/src/lib/CommunityLink.svelte
+++ b/src/lib/CommunityLink.svelte
@@ -39,7 +39,7 @@
 	{#if inlineLink}
 		<Tooltip>
 			<div slot="tooltip" class="community-tooltip">
-				<Stack gap={2} dir="c">
+				<Stack gap={1} dir="c">
 					<Stack gap={2} dir="r" align="center">
 						{#if community.icon && showIcon}
 							<div class="community-avatar large">
@@ -53,6 +53,9 @@
 					<div class="address">
 						<NameAtInstance place={community} prefix="!" />
 					</div>
+					<p class="m-0">
+						Created <OriginDate date={community.published} /> ({toRelativeTime(community.published)})
+					</p>
 					<slot name="tooltip" />
 				</Stack>
 			</div>
@@ -93,6 +96,7 @@
 	import Avatar from './Avatar.svelte';
 	import Image from './Image.svelte';
 	import { nameAtInstance } from './nav-utils';
+	import { toRelativeTime } from './utils';
 	import CommunityBadges from './feeds/posts/CommunityBadges.svelte';
 	import type { Community } from 'lemmy-js-client';
 	import NameAtInstance from './NameAtInstance.svelte';
@@ -100,6 +104,7 @@
 	import { profile } from './profiles/profiles';
 	import { getSettingsContext } from './settings-context';
 	import { createEventDispatcher } from 'svelte';
+	import OriginDate from './OriginDate.svelte';
 
 	export let cl = '';
 	export let variant: 'a' | 'button' | 'span' = 'a';

--- a/src/lib/CommunityLink.svelte
+++ b/src/lib/CommunityLink.svelte
@@ -21,6 +21,10 @@
 			width: 3rem;
 		}
 	}
+	.community-tooltip {
+		// crosspost names can be long, don't let it get too big, though this is still huge unless on a phone
+		max-width: 80vw;
+	}
 </style>
 
 <!-- svelte-ignore a11y-no-static-element-interactions -->
@@ -35,19 +39,22 @@
 	{#if inlineLink}
 		<Tooltip>
 			<div slot="tooltip" class="community-tooltip">
-				<Stack gap={2} dir="r" align="center">
-					{#if community.icon && showIcon}
-						<div class="community-avatar large">
-							<Image src={community.icon} mode="thumbnail" />
-						</div>
-					{/if}
-					<h1 class="sx-font-size-4 m-0">
-						{community.title || community.name}
-					</h1>
+				<Stack gap={2} dir="c">
+					<Stack gap={2} dir="r" align="center">
+						{#if community.icon && showIcon}
+							<div class="community-avatar large">
+								<Image src={community.icon} mode="thumbnail" />
+							</div>
+						{/if}
+						<h1 class="sx-font-size-4 m-0">
+							{community.title || community.name}
+						</h1>
+					</Stack>
+					<div class="address">
+						<NameAtInstance place={community} prefix="!" />
+					</div>
+					<slot name="tooltip" />
 				</Stack>
-				{#if community.title}
-					<NameAtInstance place={community} prefix="!" />
-				{/if}
 			</div>
 			<span class="f-row gap-1 align-items-center">
 				{#if community.icon && showIcon}

--- a/src/lib/CommunityLink.svelte
+++ b/src/lib/CommunityLink.svelte
@@ -23,10 +23,14 @@
 	}
 </style>
 
-<a
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<svelte:element
+	this={variant}
 	href={href ? href : `/${$profile.instance}/c/${communityName}`}
+	class={cl}
 	class:inline-link={inlineLink}
 	data-sveltekit-preload-data="off"
+	on:click={() => dispatch('select', community)}
 >
 	{#if inlineLink}
 		<Tooltip>
@@ -70,9 +74,12 @@
 			<span>
 				<NameAtInstance place={community} displayName={community.title} prefix="" />
 			</span>
+			{#if showBadges}
+				<CommunityBadges {community} />
+			{/if}
 		</Stack>
 	{/if}
-</a>
+</svelte:element>
 
 <script lang="ts">
 	import { Stack, Tooltip } from 'sheodox-ui';
@@ -85,7 +92,10 @@
 	import EllipsisText from './EllipsisText.svelte';
 	import { profile } from './profiles/profiles';
 	import { getSettingsContext } from './settings-context';
+	import { createEventDispatcher } from 'svelte';
 
+	export let cl = '';
+	export let variant: 'a' | 'button' | 'span' = 'a';
 	export let community: Community;
 	export let inlineLink = true;
 	// if the link should actually go somewhere else, but still have community "branding", use that link instead.
@@ -93,6 +103,10 @@
 	// link should actually go to the post in that community
 	export let href: string | null = null;
 	export let showBadges = true;
+
+	const dispatch = createEventDispatcher<{
+		select: Community;
+	}>();
 
 	const { nsfwImageHandling } = getSettingsContext();
 

--- a/src/lib/CommunityLink.svelte
+++ b/src/lib/CommunityLink.svelte
@@ -50,9 +50,11 @@
 							{community.title || community.name}
 						</h1>
 					</Stack>
+
 					<div class="address">
-						<NameAtInstance place={community} prefix="!" />
+						<NameAtInstance place={community} prefix="!" alwaysShowInstance />
 					</div>
+
 					<p class="m-0">
 						Created <OriginDate date={community.published} /> ({toRelativeTime(community.published)})
 					</p>

--- a/src/lib/InstanceSelector.svelte
+++ b/src/lib/InstanceSelector.svelte
@@ -1,0 +1,101 @@
+<style>
+	.card :global(.instances-list) {
+		max-height: 50rem;
+		overflow: auto;
+	}
+</style>
+
+<div class="card">
+	<Stack cl="card-body" dir="c" gap={2}>
+		<Search bind:value={searchText} {placeholder} />
+		{#if searchResults.length}
+			<Stack cl="instances-list sx-list" dir="c">
+				{#if $searchState.busy}
+					<div>
+						<Spinner />
+					</div>
+				{:else}
+					{#each searchResults as instance (instance.id)}
+						<div class="sx-list-item action">
+							<button
+								class="text-align-left"
+								on:click={() => {
+									dispatch('select', instance);
+									if (clearOnSelect) {
+										searchText = '';
+										searchResults = [];
+									}
+								}}
+								>{instance.domain}
+							</button>
+						</div>
+					{/each}
+				{/if}
+			</Stack>
+		{/if}
+	</Stack>
+</div>
+
+<script lang="ts">
+	import { Search, Stack } from 'sheodox-ui';
+	import { profile } from './profiles/profiles';
+	import { Throttler, createStatefulAction, safeUrl } from './utils';
+	import type { Instance } from 'lemmy-js-client';
+	import Spinner from './Spinner.svelte';
+	import { createEventDispatcher, onMount } from 'svelte';
+
+	export let placeholder = '';
+	export let clearOnSelect = false;
+
+	const dispatch = createEventDispatcher<{
+		select: Instance;
+	}>();
+
+	$: client = $profile.client;
+
+	let fullInstanceList: Instance[] = [];
+	let searchText = '';
+	let searchResults: Instance[] = [];
+
+	$: onSearchChange(searchText);
+
+	const searchThrottled = new Throttler(() => $searchState.submit(), 1000, true);
+
+	function onSearchChange(searchText: string) {
+		if (searchText) {
+			searchThrottled.run();
+		} else {
+			searchResults = [];
+		}
+	}
+
+	onMount(async () => {
+		const res = await client.getFederatedInstances();
+
+		const toMap = (instance: Instance): [number, Instance] => [instance.id, instance];
+
+		fullInstanceList = Array.from(
+			new Map([
+				// combine, but de-dupe instances, don't know if an instance could be in both
+				...(res.federated_instances?.allowed.map(toMap) ?? []),
+				...(res.federated_instances?.linked.map(toMap) ?? [])
+			]).values()
+		).sort((a, b) => {
+			return a.domain.localeCompare(b.domain);
+		});
+	});
+
+	const searchState = createStatefulAction<void>(async function searchCommunities() {
+		searchResults = [];
+		if (!searchText) {
+			return;
+		}
+
+		// if they paste a url, grab just the hostname part
+		const cleanSearchText = safeUrl(searchText)?.hostname ?? searchText;
+
+		searchResults = fullInstanceList.filter((inst) => {
+			return inst.domain.includes(cleanSearchText);
+		});
+	});
+</script>

--- a/src/lib/OriginDate.svelte
+++ b/src/lib/OriginDate.svelte
@@ -1,0 +1,12 @@
+{dateFormatter.format(parseDate(date))}
+
+<script lang="ts">
+	import { parseDate } from './utils';
+
+	// accepts an ISO date string, so it can just be passed without parsing
+	export let date: string;
+
+	const dateFormatter = new Intl.DateTimeFormat('en', {
+		dateStyle: 'medium'
+	});
+</script>

--- a/src/lib/UserLink.svelte
+++ b/src/lib/UserLink.svelte
@@ -18,11 +18,14 @@
 		</Stack>
 		<span> {creatorName}</span>
 	</div>
-	<a
+	<!-- svelte-ignore a11y-no-static-element-interactions -->
+	<svelte:element
+		this={variant}
 		href="/{$profile.instance}/u/{creatorName}"
 		class="inline-link f-row gap-1 align-items-center"
 		data-sveltekit-preload-data="off"
 		class:op={isOP}
+		on:click={() => dispatch('select', user)}
 	>
 		{#if (user.avatar && showAvatar) || showAvatarFallback}
 			<div class="user-avatar inline">
@@ -32,7 +35,7 @@
 		<span>
 			<NameAtInstance place={user} displayName={user.display_name} prefix="" />
 		</span>
-	</a>
+	</svelte:element>
 </Tooltip>
 
 <script lang="ts">
@@ -42,10 +45,16 @@
 	import type { Person } from 'lemmy-js-client';
 	import { nameAtInstance } from './nav-utils';
 	import { profile } from './profiles/profiles';
+	import { createEventDispatcher } from 'svelte';
 
+	export let variant: 'a' | 'button' | 'span' = 'a';
 	export let user: Person;
 	export let isOP = false;
 	export let showAvatarFallback = false;
+
+	const dispatch = createEventDispatcher<{
+		select: Person;
+	}>();
 
 	$: creatorName = nameAtInstance(user);
 

--- a/src/lib/UserLink.svelte
+++ b/src/lib/UserLink.svelte
@@ -16,7 +16,10 @@
 				{user.display_name ?? user.name}
 			</h1>
 		</Stack>
-		<span> {creatorName}</span>
+
+		<div class="address">
+			<NameAtInstance place={user} prefix="@" />
+		</div>
 	</div>
 	<!-- svelte-ignore a11y-no-static-element-interactions -->
 	<svelte:element

--- a/src/lib/UserLink.svelte
+++ b/src/lib/UserLink.svelte
@@ -6,20 +6,26 @@
 
 <Tooltip>
 	<div slot="tooltip">
-		<Stack gap={2} dir="r" align="center">
-			{#if user.avatar && showAvatar}
-				<div class="user-avatar">
-					<Avatar src={user.avatar} icon="user" size="3rem" />
-				</div>
-			{/if}
-			<h1 class="sx-font-size-4 m-0">
-				{user.display_name ?? user.name}
-			</h1>
-		</Stack>
+		<Stack gap={1} dir="c">
+			<Stack gap={2} dir="r" align="center">
+				{#if user.avatar && showAvatar}
+					<div class="user-avatar">
+						<Avatar src={user.avatar} icon="user" size="3rem" />
+					</div>
+				{/if}
+				<h1 class="sx-font-size-4 m-0">
+					{user.display_name ?? user.name}
+				</h1>
+			</Stack>
 
-		<div class="address">
-			<NameAtInstance place={user} prefix="@" />
-		</div>
+			<div class="address">
+				<NameAtInstance place={user} prefix="@" alwaysShowInstance />
+			</div>
+
+			<p class="m-0">
+				Joined <OriginDate date={user.published} /> ({toRelativeTime(user.published)})
+			</p>
+		</Stack>
 	</div>
 	<!-- svelte-ignore a11y-no-static-element-interactions -->
 	<svelte:element
@@ -49,6 +55,8 @@
 	import { nameAtInstance } from './nav-utils';
 	import { profile } from './profiles/profiles';
 	import { createEventDispatcher } from 'svelte';
+	import { toRelativeTime } from './utils';
+	import OriginDate from './OriginDate.svelte';
 
 	export let variant: 'a' | 'button' | 'span' = 'a';
 	export let user: Person;

--- a/src/lib/UserSelector.svelte
+++ b/src/lib/UserSelector.svelte
@@ -1,0 +1,122 @@
+<style>
+	.card :global(.users-list) {
+		max-height: 50rem;
+		overflow: auto;
+	}
+</style>
+
+<div class="card">
+	<Stack cl="card-body" dir="c" gap={2}>
+		<Search bind:value={searchText} {placeholder} />
+		{#if $searchState.busy}
+			<div class="sx-font-size-8 f-column align-items-center">
+				<Spinner />
+			</div>
+		{:else if userList.length}
+			<Stack cl="users-list sx-list" dir="c">
+				{#each userList as user (user.id)}
+					<div class="sx-list-item action">
+						<UserLink
+							{user}
+							variant="button"
+							showAvatarFallback
+							on:select={(e) => {
+								dispatch('select', e.detail);
+								if (clearOnSelect) {
+									searchText = '';
+									searchResults = [];
+								}
+							}}
+						/>
+					</div>
+				{/each}
+			</Stack>
+		{/if}
+	</Stack>
+</div>
+
+<script lang="ts">
+	import { Search, Stack } from 'sheodox-ui';
+	import { profile } from './profiles/profiles';
+	import { Throttler, createStatefulAction } from './utils';
+	import type { Person } from 'lemmy-js-client';
+	import Spinner from './Spinner.svelte';
+	import UserLink from './UserLink.svelte';
+	import { createEventDispatcher } from 'svelte';
+	import { getAppContext } from './app-context';
+
+	export let placeholder = '';
+	export let clearOnSelect = false;
+
+	const dispatch = createEventDispatcher<{
+		select: Person;
+	}>();
+
+	const { siteMeta } = getAppContext();
+
+	$: client = $profile.client;
+
+	let searchText = '';
+	let searchResults: Person[] = [];
+
+	$: userList =
+		searchText === '' ? [] : searchResults.filter((p) => p.id !== $siteMeta.my_user?.local_user_view.person.id);
+
+	$: onSearchChange(searchText);
+
+	const searchThrottled = new Throttler(() => $searchState.submit(), 1000, true);
+
+	function onSearchChange(searchText: string) {
+		if (searchText) {
+			searchThrottled.run();
+		} else {
+			searchResults = [];
+		}
+	}
+
+	const searchState = createStatefulAction<void>(async function searchCommunities() {
+		if (!searchText) {
+			searchResults = [];
+			return;
+		}
+
+		// eliminate race conditions by caching what was searched so we can ignore search results if the query has changed by the time we get the results
+		let searched = searchText;
+
+		if (/.@./.test(searchText)) {
+			try {
+				const instanceName = searchText.split('@')[1]?.trim();
+
+				//  make sure the instance name looks kinda valid
+				if (!instanceName || !/.\../.test(instanceName)) {
+					return;
+				}
+
+				const res = await client.getPersonDetails({
+					username: searchText,
+					limit: 1
+				});
+
+				if (searched === searchText && res.person_view) {
+					searchResults = [res.person_view.person];
+				}
+			} catch (e) {
+				console.log('user direct search caught', e);
+			}
+		} else {
+			const userSearch = await client.search({
+				type_: 'Users',
+				q: searchText,
+				limit: 50,
+				sort: 'TopAll'
+			});
+
+			// don't give results for the wrong search if it's changed by now
+			if (searched !== searchText) {
+				return;
+			}
+
+			searchResults = userSearch.users.map((pv) => pv.person);
+		}
+	});
+</script>

--- a/src/lib/feeds/posts/PostLayout.svelte
+++ b/src/lib/feeds/posts/PostLayout.svelte
@@ -106,7 +106,12 @@
 	<Stack dir="r" gap={1} cl="f-wrap ml-2 mb-4">
 		Cross-posted to:
 		{#each crossPosts as pv}
-			<CommunityLink href="/{$profile.instance}/post/{pv.post.id}" community={pv.community} />
+			<CommunityLink href="/{$profile.instance}/post/{pv.post.id}" community={pv.community}>
+				<svelte:fragment slot="tooltip">
+					<p class="m-0">{pv.post.name}</p>
+					<p class="m-0"><Icon icon="user" /> {nameAtInstance(pv.creator, pv.creator.display_name)}</p>
+				</svelte:fragment>
+			</CommunityLink>
 		{/each}
 	</Stack>
 {/if}
@@ -155,6 +160,7 @@
 	import PostCommentCount from './PostCommentCount.svelte';
 	import { getCommunityContext } from '$lib/community-context/community-context';
 	import { goto } from '$app/navigation';
+	import NameAtInstance from '$lib/NameAtInstance.svelte';
 
 	export let postView: PostView;
 	export let readOnly = false;

--- a/src/lib/feeds/posts/PostLayout.svelte
+++ b/src/lib/feeds/posts/PostLayout.svelte
@@ -108,8 +108,29 @@
 		{#each crossPosts as pv}
 			<CommunityLink href="/{$profile.instance}/post/{pv.post.id}" community={pv.community}>
 				<svelte:fragment slot="tooltip">
+					<hr class="w-100" />
 					<p class="m-0">{pv.post.name}</p>
-					<p class="m-0"><Icon icon="user" /> {nameAtInstance(pv.creator, pv.creator.display_name)}</p>
+					<p class="m-0 f-row gap-2">
+						{#if $profile.settings.show_scores}
+							<span>
+								<Icon icon="arrow-up" />
+								{pv.counts.score}
+							</span>
+						{/if}
+						<span>
+							<Icon icon="comments" />
+							{pv.counts.comments}
+						</span>
+						<span>
+							<Icon icon="user" />
+							{nameAtInstance(pv.creator, pv.creator.display_name)}
+						</span>
+					</p>
+					<p class="m-0">
+						Posted {$showRelativeDates
+							? toRelativeTime(pv.post.published)
+							: parseDate(pv.post.published).toLocaleString()}
+					</p>
 				</svelte:fragment>
 			</CommunityLink>
 		{/each}
@@ -149,7 +170,7 @@
 	import UserBadges from './UserBadges.svelte';
 	import ExtraActions from '$lib/ExtraActions.svelte';
 	import type { PostFeatureType, PostView } from 'lemmy-js-client';
-	import { createStatefulAction, type ExtraAction } from '$lib/utils';
+	import { createStatefulAction, parseDate, toRelativeTime, type ExtraAction } from '$lib/utils';
 	import { profile } from '$lib/profiles/profiles';
 	import { getContentViewStore, postViewToContentView } from '$lib/content-views';
 	import { getModActionPending, getModContext } from '$lib/mod/mod-context';
@@ -183,7 +204,8 @@
 	const modContext = getModContext();
 	const { siteMeta } = getAppContext();
 	const { weaklyGetCommunity, getFullCommunity } = getCommunityContext();
-	const { feedLayout, postPreviewLayout, showModlogWarning, showModlogWarningModerated } = getSettingsContext();
+	const { feedLayout, postPreviewLayout, showModlogWarning, showModlogWarningModerated, showRelativeDates } =
+		getSettingsContext();
 
 	$: layout = forceLayout ?? $postPreviewLayout;
 

--- a/src/lib/feeds/posts/PostLayout.svelte
+++ b/src/lib/feeds/posts/PostLayout.svelte
@@ -160,7 +160,6 @@
 	import PostCommentCount from './PostCommentCount.svelte';
 	import { getCommunityContext } from '$lib/community-context/community-context';
 	import { goto } from '$app/navigation';
-	import NameAtInstance from '$lib/NameAtInstance.svelte';
 
 	export let postView: PostView;
 	export let readOnly = false;

--- a/src/lib/feeds/posts/previews/CardPostPreview.svelte
+++ b/src/lib/feeds/posts/previews/CardPostPreview.svelte
@@ -3,6 +3,7 @@
 		width: 50rem;
 		max-width: 100%;
 		margin: 0 auto;
+		position: relative;
 	}
 
 	article:focus {
@@ -13,9 +14,29 @@
 			outline-offset: 2px;
 		}
 	}
+	article :global(.post-preview-card) {
+		overflow: hidden;
+		position: relative;
+	}
 	.post :global(.card) {
 		overflow: hidden;
 		border: 1px solid var(--sx-gray-transparent);
+	}
+	.background-glass {
+		filter: blur(30px);
+		position: absolute;
+		inset: 0;
+		overflow: hidden;
+		opacity: 0.12;
+		z-index: 0;
+		:global(img) {
+			object-fit: cover;
+			height: 100%;
+		}
+	}
+	article :global(.post-card-content) {
+		position: relative;
+		z-index: 1;
 	}
 </style>
 
@@ -25,7 +46,12 @@
 	bind:this={articleEl}
 >
 	<Stack dir="c" gap={2} cl="card post-preview-card">
-		<Stack dir="c" gap={2}>
+		{#if $postCardLayoutFrostedGlassBackground && postAssertions.imageSrc && !postView.post.nsfw}
+			<div class="background-glass" inert>
+				<Image mode="thumbnail" src={postAssertions.imageSrc} thumbnailResolution={32} lazy={false} />
+			</div>
+		{/if}
+		<Stack dir="c" gap={2} cl="post-card-content">
 			<div class="responsive-text px-2 pt-2">
 				<Stack dir="r" gap={1} align="start" justify="between" cl="f-wrap">
 					<Stack dir="r" gap={1} align="center" cl="f-wrap">
@@ -93,6 +119,7 @@
 	import PostBody from './PostBody.svelte';
 	import PostEmbed from '../PostEmbed.svelte';
 	import { getSettingsContext } from '$lib/settings-context';
+	import Image from '$lib/Image.svelte';
 
 	const dispatch = createEventDispatcher<{
 		overlay: number;
@@ -109,7 +136,7 @@
 
 	let articleEl: HTMLElement;
 
-	const { postCardLayoutLeftAlignedButtons } = getSettingsContext();
+	const { postCardLayoutLeftAlignedButtons, postCardLayoutFrostedGlassBackground } = getSettingsContext();
 
 	$: postAssertions = makePostAssertions(postView);
 </script>

--- a/src/lib/settings-context.ts
+++ b/src/lib/settings-context.ts
@@ -97,6 +97,7 @@ export interface AlexandriteSettings {
 	postPreviewLayout: PostPreviewLayout;
 	postListLayoutContentPreview: boolean;
 	postCardLayoutLeftAlignedButtons: boolean;
+	postCardLayoutFrostedGlassBackground: boolean;
 	// whether to show a confirm page before showing the actual modlog
 	showModlogWarning: boolean;
 	// same as above, but for communities the user is responsible for
@@ -124,6 +125,7 @@ export const AlexandriteSettingsDefaults: AlexandriteSettings = {
 	postPreviewLayout: probablyMobile ? 'CARD' : 'LIST',
 	postListLayoutContentPreview: false,
 	postCardLayoutLeftAlignedButtons: true,
+	postCardLayoutFrostedGlassBackground: true,
 	commentDefaultSort: 'Hot',
 	showModlogWarning: true,
 	showModlogWarningModerated: true

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -297,11 +297,11 @@ export function isInteractiveElementBetween(container: HTMLElement, eventTarget:
 	return within('button') || within('a');
 }
 
-const relativeTimeFormat = new Intl.RelativeTimeFormat(navigator.language, {
-	style: 'narrow'
-});
 export function toRelativeTime(isoDate: string) {
-	const d = parseDate(isoDate),
+	const relativeTimeFormat = new Intl.RelativeTimeFormat(navigator.language, {
+			style: 'narrow'
+		}),
+		d = parseDate(isoDate),
 		now = new Date(),
 		diff = {
 			years: differenceInYears(d, now),

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,7 +1,15 @@
 import { goto } from '$app/navigation';
 import { readable, writable, type Updater, type Writable } from 'svelte/store';
 import { getCtrlBasedHotkeys } from './app-context';
-import { parseISO } from 'date-fns';
+import {
+	differenceInDays,
+	differenceInHours,
+	differenceInMinutes,
+	differenceInMonths,
+	differenceInSeconds,
+	differenceInYears,
+	parseISO
+} from 'date-fns';
 
 export function copyToClipboard(text: string) {
 	navigator.clipboard.writeText(text);
@@ -287,6 +295,30 @@ export function isInteractiveElementBetween(container: HTMLElement, eventTarget:
 	// if they clicked something inside of an interactive element, let that
 	// element handle it instead
 	return within('button') || within('a');
+}
+
+const relativeTimeFormat = new Intl.RelativeTimeFormat(navigator.language, {
+	style: 'narrow'
+});
+export function toRelativeTime(isoDate: string) {
+	const d = parseDate(isoDate),
+		now = new Date(),
+		diff = {
+			years: differenceInYears(d, now),
+			months: differenceInMonths(d, now),
+			days: differenceInDays(d, now),
+			hours: differenceInHours(d, now),
+			minutes: differenceInMinutes(d, now),
+			seconds: differenceInSeconds(d, now)
+		};
+
+	for (const unit of ['years', 'months', 'days', 'hours', 'minutes', 'seconds'] as const) {
+		if (Math.abs(diff[unit]) > 0) {
+			return relativeTimeFormat.format(diff[unit], unit);
+		}
+	}
+
+	return '';
 }
 
 // Turns the passed element into a "button", so any clicks/enter on the element that aren't otherwise

--- a/src/routes/(app)/[instance]/+layout.svelte
+++ b/src/routes/(app)/[instance]/+layout.svelte
@@ -186,6 +186,10 @@
 			'post-card-layout-left-aligned-buttons',
 			AlexandriteSettingsDefaults.postCardLayoutLeftAlignedButtons
 		),
+		postCardLayoutFrostedGlassBackground = localStorageBackedStore(
+			'post-card-layout-frosted-glass-background',
+			AlexandriteSettingsDefaults.postCardLayoutFrostedGlassBackground
+		),
 		commentDefaultSort = localStorageBackedStore(
 			'comment-default-sort',
 			AlexandriteSettingsDefaults.commentDefaultSort
@@ -280,6 +284,7 @@
 		postPreviewLayout,
 		postListLayoutContentPreview,
 		postCardLayoutLeftAlignedButtons,
+		postCardLayoutFrostedGlassBackground,
 		commentDefaultSort,
 		showModlogWarning,
 		showModlogWarningModerated

--- a/src/routes/(app)/[instance]/create/post/+page.svelte
+++ b/src/routes/(app)/[instance]/create/post/+page.svelte
@@ -15,7 +15,11 @@
 		/>
 	</form>
 {:else}
-	<CommunitySelector />
+	<h2 class="m-0">Select a Community</h2>
+	<CommunitySelector
+		href={(com) =>
+			`/${$profile.instance}/create/post?community=${encodeURIComponent(nameAtInstance(com))}${extraQuery}`}
+	/>
 {/if}
 
 <script lang="ts">
@@ -26,12 +30,16 @@
 	import { goto } from '$app/navigation';
 	import { profile, instance } from '$lib/profiles/profiles';
 	import CommunitySelector from '$lib/CommunitySelector.svelte';
+	import { nameAtInstance } from '$lib/nav-utils';
 
 	$: client = $profile.client;
 	$: jwt = $profile.jwt;
 
 	export let data;
 	let errMsg = '';
+
+	const crossPostId = new URL(location.href).searchParams.get('crosspost');
+	const extraQuery = crossPostId && /^\d+$/.test(crossPostId) ? `&crosspost=${crossPostId}` : '';
 
 	let formElement: HTMLFormElement;
 

--- a/src/routes/(app)/[instance]/settings/FeedPostLayoutSettings.svelte
+++ b/src/routes/(app)/[instance]/settings/FeedPostLayoutSettings.svelte
@@ -6,6 +6,7 @@
 	{:else if $postPreviewLayout === 'CARD'}
 		<Fieldset legend="Card Settings">
 			<Checkbox bind:checked={$postCardLayoutLeftAlignedButtons}>Left-aligned vote buttons</Checkbox>
+			<Checkbox bind:checked={$postCardLayoutFrostedGlassBackground}>Frosted glass background</Checkbox>
 		</Fieldset>
 	{/if}
 </DescriptiveToggles>
@@ -15,5 +16,10 @@
 	import DescriptiveToggles from '$lib/DescriptiveToggles.svelte';
 	import { PostPreviewLayoutOptions, getSettingsContext } from '$lib/settings-context';
 
-	const { postPreviewLayout, postListLayoutContentPreview, postCardLayoutLeftAlignedButtons } = getSettingsContext();
+	const {
+		postPreviewLayout,
+		postListLayoutContentPreview,
+		postCardLayoutLeftAlignedButtons,
+		postCardLayoutFrostedGlassBackground
+	} = getSettingsContext();
 </script>

--- a/src/routes/(app)/[instance]/settings/blocks/+page.svelte
+++ b/src/routes/(app)/[instance]/settings/blocks/+page.svelte
@@ -76,7 +76,7 @@
 	import InstanceBlock from './InstanceBlock.svelte';
 	import CommunitySelector from '$lib/CommunitySelector.svelte';
 	import UserSelector from '$lib/UserSelector.svelte';
-	import { Community, Instance, Person } from 'lemmy-js-client';
+	import type { Community, Instance, Person } from 'lemmy-js-client';
 	import { createStatefulAction } from '$lib/utils';
 	import { profile } from '$lib/profiles/profiles';
 	import InstanceSelector from '$lib/InstanceSelector.svelte';

--- a/src/routes/(app)/[instance]/settings/blocks/+page.svelte
+++ b/src/routes/(app)/[instance]/settings/blocks/+page.svelte
@@ -1,46 +1,173 @@
-<Stack dir="c" gap={4} align="start">
-	<h2 class="m-0">Communities</h2>
-	{#if communityBlocks?.length}
-		<Blocks on:unblock={onUnblockCommunity}>
-			{#each communityBlocks as community}
-				<CommunityBlock {community} on:unblock={onUnblockCommunity} />
-			{/each}
-		</Blocks>
-	{:else}
-		<p class="m-0">You haven't blocked any communities.</p>
-	{/if}
+<style lang="scss">
+	.block-row {
+		display: flex;
+		gap: var(--sx-spacing-4);
+	}
+</style>
 
-	<h2 class="m-0">Users</h2>
-	{#if personBlocks?.length}
-		<Blocks on:unblock={onUnblockPerson}>
-			{#each personBlocks as person}
-				<PersonBlock {person} on:unblock={onUnblockPerson} />
-			{/each}
-		</Blocks>
-	{:else}
-		<p class="m-0">You haven't blocked any users.</p>
-	{/if}
+<Stack dir="c" gap={4} align="start">
+	<Blocks typeName="Communities">
+		<CommunitySelector
+			showFollowed={false}
+			gatePostable={false}
+			placeholder="Search communities to block..."
+			variant="button"
+			on:select={onBlockCommunity}
+			clearOnSelect
+		/>
+		<Accordion>
+			<span slot="title"><Icon icon="users" /> Blocked Communities ({communityBlocks?.length ?? 0})</span>
+			{#if communityBlocksSorted}
+				<div class="sx-list">
+					{#each communityBlocksSorted as community}
+						<div class="block-row sx-list-item">
+							<CommunityBlock {community} on:unblock={onUnblockCommunity} on:select={onBlockCommunity} />
+						</div>
+					{:else}
+						<p class="m-0 sx-list-item">You haven't blocked any communities.</p>
+					{/each}
+				</div>
+			{/if}
+		</Accordion>
+	</Blocks>
+
+	<Blocks typeName="Users">
+		<UserSelector placeholder={'Search users to block...'} on:select={onBlockPerson} clearOnSelect />
+		<Accordion>
+			<span slot="title"><Icon icon="user" /> Blocked Users ({personBlocks?.length ?? 0})</span>
+			{#if personBlocksSorted}
+				<div class="sx-list">
+					{#each personBlocksSorted as person}
+						<div class="block-row sx-list-item f-row align-items-center">
+							<PersonBlock {person} on:unblock={onUnblockPerson} />
+						</div>
+					{:else}
+						<p class="m-0 sx-list-item">You haven't blocked any users.</p>
+					{/each}
+				</div>
+			{/if}
+		</Accordion>
+	</Blocks>
+
+	<Blocks typeName="Instances">
+		<InstanceSelector placeholder="Search instances to block..." on:select={onBlockInstance} clearOnSelect />
+		<Accordion>
+			<span slot="title"><Icon icon="circle-nodes" /> Blocked Instances ({instanceBlocks?.length ?? 0})</span>
+			{#if instanceBlocksSorted}
+				<div class="sx-list">
+					{#each instanceBlocksSorted as instance}
+						<div class="block-row sx-list-item">
+							<InstanceBlock {instance} on:unblock={onUnblockInstance} />
+						</div>
+					{:else}
+						<p class="m-0 sx-list-item">You haven't blocked any instances.</p>
+					{/each}
+				</div>
+			{/if}
+		</Accordion>
+	</Blocks>
 </Stack>
 
 <script lang="ts">
-	import { Stack } from 'sheodox-ui';
+	import { Icon, Stack, Accordion } from 'sheodox-ui';
 	import Blocks from './Blocks.svelte';
 	import CommunityBlock from './CommunityBlock.svelte';
 	import PersonBlock from './PersonBlock.svelte';
+	import InstanceBlock from './InstanceBlock.svelte';
+	import CommunitySelector from '$lib/CommunitySelector.svelte';
+	import UserSelector from '$lib/UserSelector.svelte';
+	import { Community, Instance, Person } from 'lemmy-js-client';
+	import { createStatefulAction } from '$lib/utils';
+	import { profile } from '$lib/profiles/profiles';
+	import InstanceSelector from '$lib/InstanceSelector.svelte';
 
 	export let data;
 
-	let communityBlocks = data.siteMeta.my_user?.community_blocks
-		.map(({ community }) => community)
-		.sort((a, b) => {
-			return (a.title || a.name).localeCompare(b.title || b.name);
+	let communityBlocks = data.siteMeta.my_user?.community_blocks.map(({ community }) => community) ?? [];
+
+	$: communityBlocksSorted = [...communityBlocks].sort((a, b) => {
+		return (a.title || a.name).localeCompare(b.title || b.name);
+	});
+
+	let personBlocks = data.siteMeta.my_user?.person_blocks.map(({ target }) => target) ?? [];
+
+	$: personBlocksSorted = [...personBlocks].sort((a, b) => {
+		return a.name.localeCompare(b.name);
+	});
+
+	let instanceBlocks = data.siteMeta.my_user?.instance_blocks.map(({ instance }) => instance) ?? [];
+
+	$: instanceBlocksSorted = [...instanceBlocks].sort((a, b) => {
+		return a.domain.localeCompare(b.domain);
+	});
+
+	$: client = $profile.client;
+	$: jwt = $profile.jwt;
+
+	const communityBlockState = createStatefulAction<Community>(async (community) => {
+		if (!jwt) {
+			return;
+		}
+
+		// don't block a blocked community
+		if (communityBlocks.some((com) => com.id === community.id)) {
+			return;
+		}
+
+		await client.blockCommunity({
+			community_id: community.id,
+			block: true
 		});
 
-	let personBlocks = data.siteMeta.my_user?.person_blocks
-		.map(({ target }) => target)
-		.sort((a, b) => {
-			return a.name.localeCompare(b.name);
+		communityBlocks = [...communityBlocks, community];
+	});
+
+	const personBlockState = createStatefulAction<Person>(async (person) => {
+		if (!jwt) {
+			return;
+		}
+
+		// don't block a blocked person
+		if (personBlocks.some((p) => p.id === person.id)) {
+			return;
+		}
+
+		await client.blockPerson({
+			person_id: person.id,
+			block: true
 		});
+
+		personBlocks = [...personBlocks, person];
+	});
+
+	const instanceBlockState = createStatefulAction<Instance>(async (instance) => {
+		if (!jwt) {
+			return;
+		}
+
+		// don't block a blocked instance
+		if (instanceBlocks.some((p) => p.id === instance.id)) {
+			return;
+		}
+
+		await client.blockInstance({
+			instance_id: instance.id,
+			block: true
+		});
+
+		instanceBlocks = [...instanceBlocks, instance];
+	});
+	function onBlockCommunity(e: CustomEvent<Community>) {
+		$communityBlockState.submit(e.detail);
+	}
+
+	function onBlockPerson(e: CustomEvent<Person>) {
+		$personBlockState.submit(e.detail);
+	}
+
+	function onBlockInstance(e: CustomEvent<Instance>) {
+		$instanceBlockState.submit(e.detail);
+	}
 
 	function onUnblockCommunity(e: CustomEvent<number>) {
 		communityBlocks = communityBlocks?.filter((community) => community.id !== e.detail);
@@ -48,5 +175,9 @@
 
 	function onUnblockPerson(e: CustomEvent<number>) {
 		personBlocks = personBlocks?.filter((person) => person.id !== e.detail);
+	}
+
+	function onUnblockInstance(e: CustomEvent<number>) {
+		instanceBlocks = instanceBlocks?.filter((instance) => instance.id !== e.detail);
 	}
 </script>

--- a/src/routes/(app)/[instance]/settings/blocks/Blocks.svelte
+++ b/src/routes/(app)/[instance]/settings/blocks/Blocks.svelte
@@ -1,12 +1,17 @@
-<style>
-	.blocks {
-		display: grid;
-		grid-template-columns: 1fr 1fr;
-		align-items: center;
-		justify-content: center;
+<style lang="scss">
+	.card {
+		width: 100%;
 	}
 </style>
 
-<div class="blocks gap-2">
-	<slot />
+<div class="card p-2">
+	<div class="blocks f-column gap-4">
+		<h2 class="m-0">{typeName}</h2>
+		<slot />
+	</div>
 </div>
+
+<script lang="ts">
+	// used for the header for this section of blocks, should be something like "Communities"
+	export let typeName: string;
+</script>

--- a/src/routes/(app)/[instance]/settings/blocks/InstanceBlock.svelte
+++ b/src/routes/(app)/[instance]/settings/blocks/InstanceBlock.svelte
@@ -1,17 +1,16 @@
 <div class="f-1">
-	<CommunityLink {community} inlineLink={false} />
+	<div class="p-2">{instance.domain}</div>
 </div>
 <BusyButton on:click={$unblockState.submit} busy={$unblockState.busy} cl="tertiary">Unblock</BusyButton>
 
 <script lang="ts">
-	import type { Community } from 'lemmy-js-client';
-	import CommunityLink from '$lib/CommunityLink.svelte';
+	import type { Instance } from 'lemmy-js-client';
 	import BusyButton from '$lib/BusyButton.svelte';
 	import { createEventDispatcher } from 'svelte';
 	import { createStatefulAction } from '$lib/utils';
 	import { profile } from '$lib/profiles/profiles';
 
-	export let community: Community;
+	export let instance: Instance;
 
 	const dispatch = createEventDispatcher<{ unblock: number }>();
 	$: client = $profile.client;
@@ -22,10 +21,10 @@
 			return;
 		}
 
-		await client.blockCommunity({
-			community_id: community.id,
+		await client.blockInstance({
+			instance_id: instance.id,
 			block: false
 		});
-		dispatch('unblock', community.id);
+		dispatch('unblock', instance.id);
 	});
 </script>

--- a/src/routes/(app)/[instance]/settings/blocks/PersonBlock.svelte
+++ b/src/routes/(app)/[instance]/settings/blocks/PersonBlock.svelte
@@ -1,5 +1,7 @@
-<UserLink user={person} />
-<BusyButton on:click={$unblockState.submit} busy={$unblockState.busy}>Unblock</BusyButton>
+<div class="f-1">
+	<UserLink user={person} showAvatarFallback variant="a" />
+</div>
+<BusyButton on:click={$unblockState.submit} busy={$unblockState.busy} cl="tertiary">Unblock</BusyButton>
 
 <script lang="ts">
 	import type { Person } from 'lemmy-js-client';

--- a/src/routes/style.scss
+++ b/src/routes/style.scss
@@ -80,3 +80,11 @@ html.sx-theme-light {
 		}
 	}
 }
+
+.sx-tooltip .address {
+	background: var(--sx-gray-500);
+	color: var(--sx-gray-50);
+	font-family: monospace, sans-serif;
+	border-radius: 5px;
+	padding: var(--sx-spacing-1);
+}


### PR DESCRIPTION
* Redesign blocks page, add instance blocks, and search bars.
* Show addresses for users and communities on tooltips in a nicer way, matching how its done on the sidebar of those pages.
* Tooltips on links to crossposts on the post page now include the name of the post, the user who posted, how many comments it has, the score, and the post time, so you can more easily see where else people are discussing things.
* Added a frosted glass background to the card layout (a low opacity, blurred, low resolution post thumbnail, stretched across the whole card). You can turn this off with a setting.